### PR TITLE
Fix compatibility with woocommerce 2.1.9

### DIFF
--- a/wc-robokassa.php
+++ b/wc-robokassa.php
@@ -251,7 +251,13 @@ class WC_ROBOKASSA extends WC_Payment_Gateway{
 
 		return array(
 			'result' => 'success',
-			'redirect'	=> add_query_arg('order', $order->id, add_query_arg('key', $order->order_key, get_permalink(woocommerce_get_page_id('pay'))))
+			'redirect'	=> add_query_arg(array(
+                    'order' => $order->id,
+                    'order-pay' => $order->id,
+                    'key' => $order->order_key
+                ),
+                get_permalink(woocommerce_get_page_id('pay'))
+            )
 		);
 	}
 	


### PR DESCRIPTION
В новой версии обработка формы оплаты происходит по ключам, что бы форма отобразилась нужно добавить "order-pay"
